### PR TITLE
Allow forcing Go version

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,6 @@
-from binaryninja import PluginCommand
+import json
+
+from binaryninja import PluginCommand, Settings
 from .golang_parser import rename_functions, create_types, parse_go_file, print_files, comment_functions, create_type_at_address
 
 PluginCommand.register(
@@ -31,3 +33,21 @@ PluginCommand.register(
     "golang\\Parse GoLang executable",
     "Automatically apply all the transformation in the right order",
     parse_go_file)
+
+golang_settings = Settings()
+golang_settings.register_group("golang_pclntab_parser", "Golang .pclntab Parser")
+golang_version_prop = {
+    "title": "Force Go Version",
+    "type": "string",
+    "enum": [
+        "1.2",
+        "1.16",
+        "1.18",
+        "1.20",
+        "autodetect"
+    ],
+    "default": "autodetect",
+    "description": "Go Version used to compile binary",
+    "message": "Use this option to force a version if this fails (e.g. in an obfuscated binary).",
+}
+golang_settings.register_setting("golang_pclntab_parser.golangVersion", json.dumps(golang_version_prop))

--- a/types.py
+++ b/types.py
@@ -207,7 +207,13 @@ class GoPclnTab:
         self.start = start
         self.end = end
         self.raw = raw
-        self.version = GoVersion.from_magic(raw[:6])
+        version = binaryninja.Settings().get_string("golang_pclntab_parser.golangVersion")
+        self.version = {
+            "1.2": GoVersion.ver12,
+            "1.16": GoVersion.ver116,
+            "1.18": GoVersion.ver118,
+            "1.20": GoVersion.ver120,
+        }.get(version) or GoVersion.from_magic(raw[:6])
         self.valid_ptr_sizes = [4, 8]
 
     def functabFieldSize(self) -> int:


### PR DESCRIPTION
Recently I looked at a binary where manual analysis determined the version to be 1.20, but due to obfuscation the version magic was incorrect.